### PR TITLE
Fix pad length for non UTF-8 characters (fixes #13)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,8 @@ Type: Package
 Title: SpongeBob-Case Converter : spOngEboB-CASe CoNVertER
 Version: 0.4.0
 Authors@R: c(
-    person("Jay", "Qi", email = "jayqi.opensource@gmail.com", role = c("aut", "cre"))
+    person("Jay", "Qi", email = "jayqi.opensource@gmail.com", role = c("aut", "cre")),
+    person("Will", "Dearden", email = "wdearden208@gmail.com", role = c("ctb"))
     )
 Maintainer: Jay Qi <jayqi.opensource@gmail.com>
 Description: Convert text (and text in R objects) to Mocking SpongeBob case 

--- a/R/spongebobsay.R
+++ b/R/spongebobsay.R
@@ -38,6 +38,14 @@
     return(words[which.max(nchar(words))])
 }
 
+# Takes a vector of characters and pads them with spaces to the same length
+.pad_strings_to_fixed_length <- function(txt, lineLength) {
+    stopifnot(lineLength >= max(nchar(txt), 0))
+
+    out <- format(txt, width = lineLength)
+    return(out)
+}
+
 # Generator function for SpongeBob ASCII speech functions
 # Takes character strings defining symbols that will be the left boundary,
 # right boundary, and tail of the speech bubble
@@ -102,7 +110,7 @@
         maxLength <- max(nchar(txt), 0) # need to account for character(0)
 
         # Add the speech bubble left-right boundaries
-        txt <- sprintf(sprintf("%%-%ds", maxLength), txt)
+        txt <- .pad_strings_to_fixed_length(txt, maxLength)
         txt <- paste(left, txt, right)
 
         # Add the speech bubble top-bottom boundaries and combine

--- a/tests/testthat/test-spongebobsay.R
+++ b/tests/testthat/test-spongebobsay.R
@@ -147,3 +147,20 @@ test_that(".longest_word errors for non-character inputs", {
         , regexp = msg
     )
 })
+
+test_that(".pad_strings_to_fixed_length errors if length is shorter than max length", {
+    msg <- "lineLength >= max(nchar(txt), 0) is not TRUE"
+    txt <- c('aa', 'b')
+    expect_error(
+        spongebob:::.pad_strings_to_fixed_length(txt, lineLength = 1)
+        , regexp = msg
+        , fixed = TRUE
+    )
+})
+
+test_that(".pad_strings_to_fixed_length works with non-Unicode characters", {
+    expect_equal(
+        spongebob:::.pad_strings_to_fixed_length(c("pokémon", "pokemon."), lineLength = 8)
+        , c("pokémon ", "pokemon.")
+    )
+})


### PR DESCRIPTION
Fixes #13 

```
> library(spongebob)
> foo <- paste(
+     paste0("pokémon", paste(rep(".", 25), collapse = ""))
+     , paste0("pokemon", paste(rep(".", 30), collapse = ""))
+ )
> spongebobsay(foo)
 --------------------------------------- 
| pOkÉmON.........................      |
| pOkEMon.............................. |
 --------------------------------------- 
  \\
   \\    *
          *
     ----//-------
     \..C/--..--/ \   `A
      (@ )  ( @) \  \// |w
       \          \  \---/
        HGGGGGGG    \    /`
        V `---------`--'
            <<    <<
           ###   ###
```